### PR TITLE
Master - Survey update to modern input fields

### DIFF
--- a/Kernel/Modules/AgentSurveyAdd.pm
+++ b/Kernel/Modules/AgentSurveyAdd.pm
@@ -119,12 +119,12 @@ sub _SurveyAddMask {
     my $QueueString = $LayoutObject->BuildSelection(
         Data         => \%Queues,
         Name         => 'Queues',
-        Size         => 6,
         Multiple     => 1,
         PossibleNone => 0,
         Sort         => 'AlphanumericValue',
         Translation  => 0,
         SelectedID   => $FormElements{Queues},
+        Class        => 'Modernize',
     );
 
     # get config object
@@ -143,12 +143,12 @@ sub _SurveyAddMask {
             my $TicketTypeStrg = $LayoutObject->BuildSelection(
                 Data         => \%TicketTypes,
                 Name         => 'TicketTypeIDs',
-                Size         => 6,
                 Multiple     => 1,
                 PossibleNone => 0,
                 Sort         => 'AlphanumericValue',
                 Translation  => 0,
                 SelectedID   => $FormElements{TicketTypeIDs},
+                Class        => 'Modernize',
             );
 
             $LayoutObject->Block(
@@ -175,12 +175,12 @@ sub _SurveyAddMask {
             my $ServiceStrg = $LayoutObject->BuildSelection(
                 Data         => \%Services,
                 Name         => 'ServiceIDs',
-                Size         => 6,
                 Multiple     => 1,
                 PossibleNone => 0,
                 Sort         => 'AlphanumericValue',
                 Translation  => 0,
                 SelectedID   => $FormElements{ServiceIDs},
+                Class        => 'Modernize',
             );
 
             $LayoutObject->Block(

--- a/Kernel/Modules/AgentSurveyEdit.pm
+++ b/Kernel/Modules/AgentSurveyEdit.pm
@@ -155,12 +155,12 @@ sub _SurveyEditMask {
     my $QueueString = $LayoutObject->BuildSelection(
         Data         => \%Queues,
         Name         => 'Queues',
-        Size         => 6,
         Multiple     => 1,
         PossibleNone => 0,
         Sort         => 'AlphanumericValue',
         Translation  => 0,
         SelectedID   => $FormElements{Queues} || $Param{Queues},
+        Class        => 'Modernize',
     );
 
     # get config object
@@ -179,12 +179,12 @@ sub _SurveyEditMask {
             my $TicketTypeStrg = $LayoutObject->BuildSelection(
                 Data         => \%TicketTypes,
                 Name         => 'TicketTypeIDs',
-                Size         => 6,
                 Multiple     => 1,
                 PossibleNone => 0,
                 Sort         => 'AlphanumericValue',
                 Translation  => 0,
                 SelectedID   => $FormElements{TicketTypeIDs} || $Param{TicketTypeIDs},
+                Class        => 'Modernize',
             );
 
             $LayoutObject->Block(
@@ -211,12 +211,12 @@ sub _SurveyEditMask {
             my $ServiceStrg = $LayoutObject->BuildSelection(
                 Data         => \%Services,
                 Name         => 'ServiceIDs',
-                Size         => 6,
                 Multiple     => 1,
                 PossibleNone => 0,
                 Sort         => 'AlphanumericValue',
                 Translation  => 0,
                 SelectedID   => $FormElements{ServiceIDs} || $Param{ServiceIDs},
+                Class        => 'Modernize',
             );
 
             $LayoutObject->Block(

--- a/Kernel/Modules/AgentSurveyEditQuestions.pm
+++ b/Kernel/Modules/AgentSurveyEditQuestions.pm
@@ -546,6 +546,7 @@ sub _MaskQuestionOverview {
             SelectedValue => 'Yes/No',
             Translation   => 1,
             Title         => $LayoutObject->{LanguageObject}->Translate('Question Type'),
+            Class         => 'Modernize',
         );
 
         $ArrayHashRef = [
@@ -566,6 +567,7 @@ sub _MaskQuestionOverview {
             ID            => 'AnswerRequired',
             SelectedValue => 'Yes',
             Translation   => 1,
+            Class         => 'Modernize',
         );
 
         my $QuestionErrorClass = '';
@@ -756,6 +758,7 @@ sub _MaskQuestionEdit {
         ID            => 'AnswerRequired',
         SelectedValue => 'Yes',
         Translation   => 1,
+        Class         => 'Modernize',
     );
 
     # print the main body


### PR DESCRIPTION
Hi @carlosfrodriguez 

I have made this PR with update to modern fields, there were not specific situation like there are in ITSM with fields in a table or dialog. I believe it could be updated. I saw today that there is some PR with update for theses modern fields. If we should some improvement here we will be able to do that.

I did not change dropdown in AgentSureyZoom for Change Status. It is similar to Move dropdown in TicketZoom. I see that this one in TicketZoom was not changed.
We can change it if it will be necessary. I wanted to make PR for it to be able to finish all tasks connected with Survey and that we can continue with porting to OM for other public package modules. 

Regards
Zoran