### PR TITLE
Master Survey - reverted size param in build selection for modern input fields

### DIFF
--- a/Kernel/Modules/AgentSurveyAdd.pm
+++ b/Kernel/Modules/AgentSurveyAdd.pm
@@ -119,6 +119,7 @@ sub _SurveyAddMask {
     my $QueueString = $LayoutObject->BuildSelection(
         Data         => \%Queues,
         Name         => 'Queues',
+        Size         => 6,
         Multiple     => 1,
         PossibleNone => 0,
         Sort         => 'AlphanumericValue',
@@ -143,6 +144,7 @@ sub _SurveyAddMask {
             my $TicketTypeStrg = $LayoutObject->BuildSelection(
                 Data         => \%TicketTypes,
                 Name         => 'TicketTypeIDs',
+                Size         => 6,
                 Multiple     => 1,
                 PossibleNone => 0,
                 Sort         => 'AlphanumericValue',
@@ -175,6 +177,7 @@ sub _SurveyAddMask {
             my $ServiceStrg = $LayoutObject->BuildSelection(
                 Data         => \%Services,
                 Name         => 'ServiceIDs',
+                Size         => 6,
                 Multiple     => 1,
                 PossibleNone => 0,
                 Sort         => 'AlphanumericValue',

--- a/Kernel/Modules/AgentSurveyEdit.pm
+++ b/Kernel/Modules/AgentSurveyEdit.pm
@@ -155,6 +155,7 @@ sub _SurveyEditMask {
     my $QueueString = $LayoutObject->BuildSelection(
         Data         => \%Queues,
         Name         => 'Queues',
+        Size         => 6,
         Multiple     => 1,
         PossibleNone => 0,
         Sort         => 'AlphanumericValue',
@@ -179,6 +180,7 @@ sub _SurveyEditMask {
             my $TicketTypeStrg = $LayoutObject->BuildSelection(
                 Data         => \%TicketTypes,
                 Name         => 'TicketTypeIDs',
+                Size         => 6,
                 Multiple     => 1,
                 PossibleNone => 0,
                 Sort         => 'AlphanumericValue',
@@ -211,6 +213,7 @@ sub _SurveyEditMask {
             my $ServiceStrg = $LayoutObject->BuildSelection(
                 Data         => \%Services,
                 Name         => 'ServiceIDs',
+                Size         => 6,
                 Multiple     => 1,
                 PossibleNone => 0,
                 Sort         => 'AlphanumericValue',


### PR DESCRIPTION
Hi @carlosfrodriguez  and @mgruner 

I updated and reverted modules, where Size param had been in BuildSelection before. I have not changed values for Size param. If you think that some of them should be changed please let me know.

Rgards
Zoran