### PR TITLE
Fixed typo in charset name

### DIFF
--- a/CHANGES-Survey.md
+++ b/CHANGES-Survey.md
@@ -1,4 +1,5 @@
 #5.0.2 2015-??-??
+ - Fixed typo in charset name.
  - 2016-07-22 Fixed bug#[12184](http://bugs.otrs.org/show_bug.cgi?id=12184) - Survey Blacklist not working as expected.
 
 #5.0.1 2015-10-20

--- a/Kernel/System/Survey/Request.pm
+++ b/Kernel/System/Survey/Request.pm
@@ -431,7 +431,7 @@ sub RequestSend {
     }
 
     # get charset
-    my $Charset = $ConfigObject->Get('DefaultCharset') || 'uft-8';
+    my $Charset = $ConfigObject->Get('DefaultCharset') || 'utf-8';
 
     # get HTMLUtils object
     my $HTMLUtilsObject = $Kernel::OM->Get('Kernel::System::HTMLUtils');


### PR DESCRIPTION
Fixed typo in charset name.

Related: https://dev.ib.pl/ib/otrs-ext/issues/3
Author-Change-Id: IB#1020383
