### PR TITLE
Improved close button text

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentSurveyEditQuestions.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentSurveyEditQuestions.tt
@@ -198,7 +198,7 @@ $('.QuestionDelete').bind('click', function (Event) {
 
     </div>
     <div class="Footer">
-        <button type="submit" class="CancelClosePopup Primary CallForAction" value="[% Translate("Close") | html %]"><span><i class="fa fa-times"></i> [% Translate("Close") | html %]</span></button>
+        <button type="submit" class="CancelClosePopup Primary CallForAction" value="[% Translate("Close this window") | html %]"><span><i class="fa fa-times"></i> [% Translate("Close this window") | html %]</span></button>
     </div>
 </div>
 [% RenderBlockEnd("SurveyEditQuestions") %]

--- a/Kernel/Output/HTML/Templates/Standard/AgentSurveyStats.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentSurveyStats.tt
@@ -70,7 +70,7 @@
 
     </div>
     <div class="Footer">
-        <button type="submit" class="CancelClosePopup Primary CallForAction" value="[% Translate("Close") | html %]"><span><i class="fa fa-times"></i> [% Translate("Close") | html %]</span></button>
+        <button type="submit" class="CancelClosePopup Primary CallForAction" value="[% Translate("Close this window") | html %]"><span><i class="fa fa-times"></i> [% Translate("Close this window") | html %]</span></button>
     </div>
 </div>
 [% WRAPPER JSOnDocumentComplete %]


### PR DESCRIPTION
Hi @carlosfrodriguez 

In some languages (e. g. in Hungarian) there are different words for closing a ticket (in this case "close" is "**le**zárás" in Hungarian) and closing a window or widget (in this case "close" is "**be**zárás" in Hungarian). Because of the structure of the .po file, there is not possible to translate the two kind of "close" differently, as it contains only one instance of "close".